### PR TITLE
fix parents not updating after first one

### DIFF
--- a/src/item.service.js
+++ b/src/item.service.js
@@ -961,8 +961,7 @@ export class ItemService {
 
   async _updatedId (id, options) {
     const space = this._findSpace(id)
-
-    if (space) {
+    if (space && !options.parentId) {
       return await this._applyUpdate(id, options)
     } else {
       return await this._applyUpdate(options?.parentId, options)


### PR DESCRIPTION
Fixes problem of the parents array only returning the first parent when using the post fetch route.
Needs review and testing to see if this bricks other functionalities of the post route.